### PR TITLE
Internal PR: Add unit tests for com.thoughtworks.xstream.io.naming

### DIFF
--- a/xstream/src/test/com/thoughtworks/xstream/io/naming/StaticNameCoderTest.java
+++ b/xstream/src/test/com/thoughtworks/xstream/io/naming/StaticNameCoderTest.java
@@ -1,0 +1,50 @@
+package com.thoughtworks.xstream.io.naming;
+
+import com.thoughtworks.xstream.io.naming.StaticNameCoder;
+import java.util.HashMap;
+import junit.framework.TestCase;
+
+public class StaticNameCoderTest extends TestCase {
+
+  public void testDecodeAttribute() {
+    final HashMap<String, String> node = new HashMap<>();
+    final HashMap<String, String> attribute = new HashMap<>();
+    StaticNameCoder staticNameCoder = new StaticNameCoder(node, attribute);
+    assertEquals("non-existing attribute", staticNameCoder.decodeAttribute("non-existing attribute"));
+ 
+    attribute.put("B", "C");
+    staticNameCoder = new StaticNameCoder(node, attribute);
+    assertEquals("B", staticNameCoder.decodeAttribute("C"));
+  }
+
+  public void testDecodeNode() {
+    final HashMap<String, String> node = new HashMap<>();
+    StaticNameCoder staticNameCoder = new StaticNameCoder(node, null);
+    assertEquals("non-existing node", staticNameCoder.decodeNode("non-existing node"));
+ 
+    node.put("B", "C");
+    staticNameCoder = new StaticNameCoder(node, null);
+    assertEquals("B", staticNameCoder.decodeNode("C"));
+  }
+
+  public void testEncodeAttribute() {
+    final HashMap<String, String> node = new HashMap<>();
+    final HashMap<String, String> attribute = new HashMap<>();
+    StaticNameCoder staticNameCoder = new StaticNameCoder(node, attribute);
+    assertEquals("non-existing attribute", staticNameCoder.encodeAttribute("non-existing attribute"));
+
+    attribute.put("B", "C");
+    staticNameCoder = new StaticNameCoder(node, attribute);
+    assertEquals("C", staticNameCoder.encodeAttribute("B"));
+  }
+
+  public void testEncodeNode() {
+    final HashMap<String, String> node = new HashMap<>();
+    StaticNameCoder staticNameCoder = new StaticNameCoder(node, null);
+    assertEquals("non-existing node", staticNameCoder.encodeNode("non-existing node"));
+
+    node.put("B", "C");
+    staticNameCoder = new StaticNameCoder(node, null);
+    assertEquals("C", staticNameCoder.encodeNode("B"));
+  }
+}


### PR DESCRIPTION
(They use junit3, so I converted the tests from junit4 to that, which wasn't too tricky).

Hi,

I've analysed your code base and noticed that `com.thoughtworks.xstream.io.naming.StaticNameCoder` is not fully tested.

I've written some tests for the functions in this class with the help of [Diffblue](https://www.diffblue.com/) [Cover](https://www.diffblue.com/products).

Hopefully these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.